### PR TITLE
Fix dovecot DB name

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Further config can be changed by modifying the compose file.
 ```bash
 docker-compose up -d
 ```
+4. Manage user and alias at `https://hostname`. Set up admin user at `https://hostname/setup.php`.
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - key_file
       - dh_file
     environment:
-      POSTGRES_DB: ${DB_USER}
+      POSTGRES_DB: postfix
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
 


### PR DESCRIPTION
Fix dovecot's database name variable in docker-compose.
Update README with instruction for PostfixAdmin.